### PR TITLE
Don't include tags if there's no URL 'host'

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -99,19 +99,21 @@ class Plugin {
 				return;
 			}
 
-			$shlink = $this->get_post_shlink($post);
-			$site_url = parse_url(get_site_url());
-
 			$request = [
 				'longUrl' => $long_url,
-				'title' => $post->post_title,
-				'tags' => [
+				'title' => $post->post_title
+			];
+
+			$site_url = parse_url(get_site_url());
+			if (! empty($site_url['host'])) {
+				$request['tags'] = [
 					'wp-shlink-onsave',
 					"wp-shlink-site:{$site_url['host']}",
 					"wp-shlink-post:{$post->ID}"
-				]
-			];
+				];
+			}
 
+			$shlink = $this->get_post_shlink($post);
 			if (empty($shlink)) {
 				$response = $this->api->create_shlink($request);
 				$this->save_post_response($response, $post);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -105,12 +105,13 @@ class Plugin {
 			];
 
 			$site_url = parse_url(get_site_url());
+
+			// This conditional exists because in some conditions, for example
+			// when a save is cron-initiated, we cannot expect a valid URL from
+			// get_site_url(). And if you omit the 'tags' part of a shlink
+			// update, the tags assigned previously are still retained.
+			// (dphiffer/2022-02-04)
 			if (! empty($site_url['host'])) {
-				// This conditional exists because in some conditions, for example
-				// when a save is cron-initiated, we cannot expect a valid URL from
-				// get_site_url(). And if you omit the 'tags' part of a shlink
-				// update, the tags assigned previously are still retained.
-				// (dphiffer/2022-02-04)
 				$request['tags'] = [
 					'wp-shlink-onsave',
 					"wp-shlink-site:{$site_url['host']}",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -117,14 +117,13 @@ class Plugin {
 			if (empty($shlink)) {
 				$response = $this->api->create_shlink($request);
 				$this->save_post_response($response, $post);
-			} else if ($shlink['long_url'] != $long_url) {
+			} else {
 				$short_code = $shlink['short_code'];
 				$response = $this->api->update_shlink($short_code, $request);
 				$this->save_post_response($response, $post);
 			}
 
 		} catch (\Exception $err) {
-			\dbug($err->getMessage());
 			if ( function_exists( '\wp_sentry_safe' ) ) {
 				\wp_sentry_safe( function ( $client ) use ( $err ) {
 					$client->captureException( $err );

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -106,6 +106,11 @@ class Plugin {
 
 			$site_url = parse_url(get_site_url());
 			if (! empty($site_url['host'])) {
+				// This conditional exists because in some conditions, for example
+				// when a save is cron-initiated, we cannot expect a valid URL from
+				// get_site_url(). And if you omit the 'tags' part of a shlink
+				// update, the tags assigned previously are still retained.
+				// (dphiffer/2022-02-04)
 				$request['tags'] = [
 					'wp-shlink-onsave',
 					"wp-shlink-site:{$site_url['host']}",


### PR DESCRIPTION
Re: https://sentry.themarkup.org/organizations/sentry/issues/25995/?project=5

Shlinks created for posts on save get tagged with `wp-shlink-site:[hostname]`. These get updated on each save, including on cron jobs for when a post is scheduled to publish. In the case where no hostname is found (like on a cron job), simply omit the tags part of the shlink request JSON.