### PR TITLE
Fix the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM wordpress:php7.4-fpm-alpine
+FROM wordpress:5.9.0-php7.4-apache
 
 # Dependencies
-RUN apk update && apk add --no-cache \
+RUN apt-get update && apt-get install -y \
 	mariadb-client \
-	composer \
 	subversion;
 
 # Setup WP-CLI
@@ -21,7 +20,10 @@ RUN touch /tmp/debug.log; \
 	chown www-data:www-data /tmp/debug.log;
 
 # Setup composer
-# See: https://getcomposer.org/
-RUN chmod +x /usr/bin/composer.phar; \
-	# Override default script that forces PHP 8.
-	echo -e "#!/bin/sh\n\n/usr/bin/composer.phar \"\$@\"" > /usr/bin/composer;
+# See: https://getcomposer.org/download/
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"; \
+	php -r "if (hash_file('sha384', 'composer-setup.php') === '906a84df04cea2aa72f40b5f787e49f22d4c2f19492ac310e8cba5b96ac8b64115ac402c8cd292b8a03482574915d1a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"; \
+	php composer-setup.php; \
+	php -r "unlink('composer-setup.php');"; \
+	mv composer.phar /usr/local/bin/composer; \
+	chmod +x /usr/local/bin/composer


### PR DESCRIPTION
- Use `wordpress:5.9.0-php7.4-apache` Docker image
- Don't install `composer` using its (non functioning) package