### PR TITLE
V2->V3 of Shlink API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.5  
 **Tested up to:** 6.5.3  
 **Requires PHP:** 7.3  
-**Stable tag:** 0.1.1  
+**Stable tag:** 0.2.0  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -60,6 +60,9 @@ __Running tests:__
 3. The post editor includes the short URL in the sidebar.
 
 ## Changelog ##
+
+### 0.2.0 ###
+* Update to Shlink v3 API
 
 ### 0.1.1 ###
 * Fix a bug with the Short Links manager

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "the-markup/smol-links",
 	"description": "Create and manage Shlink short links from WordPress",
+	"version": "0.2.0",
 	"type": "wordpress-plugin",
 	"require-dev": {
 		"phpunit/phpunit": "^9.6",

--- a/languages/smol-links.pot
+++ b/languages/smol-links.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Smol Links 0.1.1\n"
+"Project-Id-Version: Smol Links 0.2.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smol-links\n"
 "POT-Creation-Date: 2024-05-30 17:33:07+00:00\n"
 "MIME-Version: 1.0\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "smol-links",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "smol-links",
-			"version": "0.1.1",
+			"version": "0.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@primer/octicons": "^19.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "smol-links",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Create and manage Shlink short links from WordPress",
 	"main": "build/index.js",
 	"author": "The Markup",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: short url, shlink
 Requires at least: 4.5
 Tested up to: 6.5.3
 Requires PHP: 7.3
-Stable tag: 0.1.1
+Stable tag: 0.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -60,6 +60,9 @@ __Running tests:__
 3. The post editor includes the short URL in the sidebar.
 
 == Changelog ==
+
+= 0.2.0 =
+* Update to Shlink v3 API
 
 = 0.1.1 =
 * Fix a bug with the Short Links manager

--- a/smol-links.php
+++ b/smol-links.php
@@ -13,7 +13,7 @@
  * Description:       Create and manage Shlink short links from WordPress
  * Requires at least: 4.5
  * Requires PHP:      7.0
- * Version:           0.1.1
+ * Version:           0.2.0
  * Author:            The Markup
  * Author URI:        https://themarkup.org/
  * License:           GPL-2.0-or-later

--- a/src/API.php
+++ b/src/API.php
@@ -22,25 +22,25 @@ class API {
 
 	function create_shlink($args) {
 		$base_url = $this->plugin->options->get('base_url');
-		$endpoint = "$base_url/rest/v2/short-urls";
+		$endpoint = "$base_url/rest/v3/short-urls";
 		return $this->request('POST', $endpoint, $args);
 	}
 
 	function update_shlink($short_code, $args) {
 		$base_url = $this->plugin->options->get('base_url');
-		$endpoint = "$base_url/rest/v2/short-urls/$short_code";
+		$endpoint = "$base_url/rest/v3/short-urls/$short_code";
 		return $this->request('PATCH', $endpoint, $args);
 	}
 
 	function get_shlinks($args = null) {
 		$base_url = $this->plugin->options->get('base_url');
-		$endpoint = "$base_url/rest/v2/short-urls";
+		$endpoint = "$base_url/rest/v3/short-urls";
 		return $this->request('GET', $endpoint, $args);
 	}
 
 	function get_domains() {
 		$base_url = $this->plugin->options->get('base_url');
-		$endpoint = "$base_url/rest/v2/domains";
+		$endpoint = "$base_url/rest/v3/domains";
 		return $this->request('GET', $endpoint);
 	}
 

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -79,11 +79,12 @@ class SmolLinksManager {
 	}
 
 	getItemContentHTML(shlink) {
-		let title = shlink.title || shlink.longUrl;
+		const title = shlink.title || shlink.longUrl;
+		const clickTotal = shlink.visitsSummary.total;
 
 		return `<div class="smol-links-item__content">
 			<div class="smol-links-item__clicks">
-				${shlink.visitsSummary.total} clicks
+				${clickTotal} click${(clickTotal !== 1) ? 's' : ''}
 			</div>
 			<div class="smol-links-item__links">
 				<div class="smol-links-item__long-url">${title}</div>

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -80,6 +80,7 @@ class SmolLinksManager {
 
 	getItemContentHTML(shlink) {
 		let title = shlink.title || shlink.longUrl;
+		console.log(shlink);
 		return `<div class="smol-links-item__content">
 			<div class="smol-links-item__clicks">
 				${shlink.visitsCount} clicks

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -156,7 +156,9 @@ class SmolLinksManager {
 					shortCode: shortCodeField.value,
 					title: titleField.value,
 					shortUrl: '',
-					visitsCount: 0,
+					visitsSummary: {
+						total: 0,
+					},
 				}) + list.innerHTML;
 			let item = list.querySelectorAll('.smol-links-item')[0];
 			item.classList.add('smol-links-item--is-saving');

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -80,10 +80,10 @@ class SmolLinksManager {
 
 	getItemContentHTML(shlink) {
 		let title = shlink.title || shlink.longUrl;
-		console.log(shlink);
+
 		return `<div class="smol-links-item__content">
 			<div class="smol-links-item__clicks">
-				${shlink.visitsCount} clicks
+				${shlink.visitsSummary.total} clicks
 			</div>
 			<div class="smol-links-item__links">
 				<div class="smol-links-item__long-url">${title}</div>

--- a/tests/API.php
+++ b/tests/API.php
@@ -23,7 +23,9 @@ class TestAPI extends SmolLinks\API {
 			"shortUrl"       => "https://example.com/xxxxx",
 			"longUrl"        => $args['longUrl'],
 			"dateCreated"    => current_time(DATE_RFC3339),
-			"visitsCount"    => 0,
+			"visitsSummary"  => [
+				"total" => 0
+			],
 			"tags"           => $tags,
 			"meta"           => [
 				"validSince" => null,

--- a/tests/TestPlugin.php
+++ b/tests/TestPlugin.php
@@ -45,4 +45,11 @@ class TestPlugin extends WP_UnitTestCase {
 		$this->assertEquals($shlink['long_url'], 'http://example.org/?p='.$post_id);
 	}
 
+	public function test_expected_permalink() {
+		$post_id = self::factory()->post->create();
+		$post = get_post($post_id);
+		$link = $this->plugin->get_expected_permalink($post);
+
+		$this->assertEquals($link, 'http://example.org/?p='.$post_id);
+	}
 }

--- a/tests/TestPlugin.php
+++ b/tests/TestPlugin.php
@@ -39,7 +39,10 @@ class TestPlugin extends WP_UnitTestCase {
 			'post_title' => 'Testing generate_on_save'
 		]);
 		$shlink = $this->plugin->get_post_shlink(get_post($post_id));
+
 		$this->assertEquals($shlink['short_code'], 'xxxxx');
+		$this->assertEquals($shlink['short_url'], 'https://example.com/xxxxx');
+		$this->assertEquals($shlink['long_url'], 'http://example.org/?p='.$post_id);
 	}
 
 }


### PR DESCRIPTION
Also adds a couple of tests. Addresses [Issue 21](https://github.com/the-markup/smol-links/issues/21#issue-1393033312)

Pairs with [cdk-url-shortener PR:1](https://github.com/the-markup/cdk-url-shortener/pull/1)