### PR TITLE
Don't require composer autoload

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -36,7 +36,7 @@ webpack.config.js
 wp-cli.local.yml
 yarn.lock
 tests
-vendor/*
+vendor
 node_modules
 *.sql
 *.tar.gz

--- a/bin/release
+++ b/bin/release
@@ -11,6 +11,8 @@ dir="$( cd "$(dirname "$( dirname "${BASH_SOURCE[0]}" )" )" >/dev/null 2>&1 && p
 version="$(cat "$dir/readme.txt" | grep "Stable tag: " | cut -c 13-)"
 svn="$1"
 
+
+
 if [ -d "$svn/tags/$version" ] ; then
   echo "Error: $svn/tags/$version already exists"
   exit 1
@@ -27,7 +29,6 @@ echo "Creating $svn/tags/$version..."
 mkdir "$svn/tags/$version"
 rsync --recursive \
       --verbose \
-      --include="vendor/autoload.php" \
       --exclude-from=".distignore" \
       "$dir/" \
       "$svn/tags/$version/"

--- a/smol-links.php
+++ b/smol-links.php
@@ -23,6 +23,14 @@
 
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 	require_once(__DIR__ . '/vendor/autoload.php');
+} else {
+	require_once __DIR__ . '/src/API.php';
+	require_once __DIR__ . '/src/Editor.php';
+	require_once __DIR__ . '/src/Manager.php';
+	require_once __DIR__ . '/src/Options.php';
+	require_once __DIR__ . '/src/Plugin.php';
+	require_once __DIR__ . '/src/Settings.php';
+	require_once __DIR__ . '/src/ShlinkException.php';
 }
 
 add_action('plugins_loaded', function() {


### PR DESCRIPTION
Don't include `vendor/autoload.php` in the built plugin. And when there's no `vendor/autoload.php` load the class files manually.