### PR TITLE
Validate Base URL

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -167,7 +167,7 @@ class Settings {
 
 	function api_key_field() {
 		$value = htmlentities($this->plugin->options->get('api_key'));
-		echo '<input type="text" name="smol_links_options[api_key]" class="regular-text ltr" value="' . esc_attr($value) . '">';
+		echo '<input type="text" name="smol_links_options[api_key]" class="regular-text ltr" value="' . esc_attr($value) . '" required>';
 	}
 
 	function generate_on_save_field() {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -154,7 +154,15 @@ class Settings {
 
 	function base_url_field() {
 		$value = htmlentities($this->plugin->options->get('base_url'));
-		echo '<input type="text" name="smol_links_options[base_url]" class="regular-text ltr" value="' . esc_attr($value) . '">';
+		echo '<input 
+				type="url" 
+				placeholder="https://example.com" 
+				pattern="/[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/ig" 
+				name="smol_links_options[base_url]" 
+				class="regular-text ltr" 
+				value="' . esc_attr($value) . '"
+				required
+			  >';
 	}
 
 	function api_key_field() {
@@ -164,7 +172,7 @@ class Settings {
 
 	function generate_on_save_field() {
 		$value = htmlentities($this->plugin->options->get('generate_on_save'));
-		echo '<input type="checkbox" name="smol_links_options[generate_on_save]" value="1" ' . checked( 1, $value, false ) . '>';
+		echo '<input type="checkbox" name="smol_links_options[generate_on_save]" value="1" ' . checked( 1, $value, false ) . ' required >';
 	}
 
 	function default_domain_field() {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -157,7 +157,7 @@ class Settings {
 		echo '<input 
 				type="url" 
 				placeholder="https://example.com" 
-				pattern="/[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/ig" 
+				pattern="^(http(s){0,1}:\/\/.){0,1}[\-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([\-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$" 
 				name="smol_links_options[base_url]" 
 				class="regular-text ltr" 
 				value="' . esc_attr($value) . '"

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -172,7 +172,7 @@ class Settings {
 
 	function generate_on_save_field() {
 		$value = htmlentities($this->plugin->options->get('generate_on_save'));
-		echo '<input type="checkbox" name="smol_links_options[generate_on_save]" value="1" ' . checked( 1, $value, false ) . ' required >';
+		echo '<input type="checkbox" name="smol_links_options[generate_on_save]" value="1" ' . checked( 1, $value, false ) . '>';
 	}
 
 	function default_domain_field() {

--- a/src/css/settings.scss
+++ b/src/css/settings.scss
@@ -3,3 +3,12 @@
 	text-decoration: none;
 	color: #808080;
 }
+
+th+td:has(input[required]) {
+	&::after {
+		content: "required";
+		font-weight: normal;
+		margin-left: 10px;
+		color: red;
+	}
+}

--- a/src/css/settings.scss
+++ b/src/css/settings.scss
@@ -9,6 +9,6 @@ th+td:has(input[required]) {
 		content: "required";
 		font-weight: normal;
 		margin-left: 10px;
-		color: red;
+		color: #d63638;
 	}
 }


### PR DESCRIPTION
- Requires base URL to have valid format
- Makes the Base URL and API Key fields required in general
- adds some labels/styling to required fields

Addresses issue #31 