### PR TITLE
Update version to v0.4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Smol Links plugin creates and manages Shlink short links
-Copyright (C) 2022 The Markup
+Copyright (C) 2024 The Markup
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.5  
 **Tested up to:** 6.5.3  
 **Requires PHP:** 7.3  
-**Stable tag:** 0.3.1  
+**Stable tag:** 0.4.0  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -60,6 +60,10 @@ __Running tests:__
 3. The post editor includes the short URL in the sidebar.
 
 ## Changelog ##
+
+### 0.4.0 ###
+* Add search to manager interface
+* URL validation on form inputs
 
 ### 0.3.1 ###
 * Remove Composer from installation

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Create and manage Shlink short links from WordPress
 
 ## Description ##
 
-__This plugin is a work in progress; development is ongoing.__
-
 A WordPress dashboard interface for managing a self-hosted [Shlink URL shortener](https://shlink.io/) instance.
 
 * Create and edit Shlinks short links from a manager interface

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "the-markup/smol-links",
 	"description": "Create and manage Shlink short links from WordPress",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"type": "wordpress-plugin",
 	"require-dev": {
 		"phpunit/phpunit": "^9.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,35 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab44800ea305cf45586e8ebced177110",
+    "content-hash": "e0c0025888d4be8ce074c5f44eef9146",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -59,7 +59,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -75,7 +75,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/languages/smol-links.pot
+++ b/languages/smol-links.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Smol Links 0.3.1\n"
+"Project-Id-Version: Smol Links 0.4.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smol-links\n"
-"POT-Creation-Date: 2024-05-30 17:33:07+00:00\n"
+"POT-Creation-Date: 2024-06-07 17:30:48+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -28,11 +28,11 @@ msgstr ""
 msgid "Smol Links"
 msgstr ""
 
-#: src/Manager.php:188
+#: src/Manager.php:214
 msgid "Cannot connect to Shlink Server."
 msgstr ""
 
-#: src/Manager.php:189
+#: src/Manager.php:215
 msgid "Please configure Shlink API settings."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "smol-links",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "smol-links",
-			"version": "0.3.1",
+			"version": "0.4.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@primer/octicons": "^19.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "smol-links",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"description": "Create and manage Shlink short links from WordPress",
 	"main": "build/index.js",
 	"author": "The Markup",

--- a/readme.txt
+++ b/readme.txt
@@ -13,8 +13,6 @@ Create and manage Shlink short links from WordPress
 
 == Description ==
 
-__This plugin is a work in progress; development is ongoing.__
-
 A WordPress dashboard interface for managing a self-hosted [Shlink URL shortener](https://shlink.io/) instance.
 
 * Create and edit Shlinks short links from a manager interface

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: short url, shlink
 Requires at least: 4.5
 Tested up to: 6.5.3
 Requires PHP: 7.3
-Stable tag: 0.3.1
+Stable tag: 0.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -60,6 +60,10 @@ __Running tests:__
 3. The post editor includes the short URL in the sidebar.
 
 == Changelog ==
+
+= 0.4.0 =
+* Add search to manager interface
+* URL validation on form inputs
 
 = 0.3.1 =
 * Remove Composer from installation

--- a/smol-links.php
+++ b/smol-links.php
@@ -13,7 +13,7 @@
  * Description:       Create and manage Shlink short links from WordPress
  * Requires at least: 4.5
  * Requires PHP:      7.0
- * Version:           0.3.1
+ * Version:           0.4.0
  * Author:            The Markup
  * Author URI:        https://themarkup.org/
  * License:           GPL-2.0-or-later

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -91,7 +91,7 @@ class Manager {
 						name="long_url" 
 						placeholder="https://example.com"
 						id="smol-links-create__long-url" 
-						pattern="/[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/ig" 
+						pattern="^(http(s){0,1}:\/\/.){0,1}[\-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([\-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$"
 						class="smol-links-long-url regular-text ltr" 
 						required
 					/>


### PR DESCRIPTION
- Bump versions to v0.4.0
- Apply URL validation regex change to the other place we use it
- Update our LICENSE to use (c) 2024