### PR TITLE
docker-compose -> docker compose

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -5,7 +5,7 @@ set -e
 stop_containers() {
   echo "Shutting off containers..."
   echo
-  docker-compose stop
+  docker compose stop
   echo
   echo "All done!"
 }
@@ -14,12 +14,12 @@ trap stop_containers SIGINT
 
 echo "Starting containers..."
 echo
-docker-compose up -d
+docker compose up -d
 echo
 
 echo "Running composer install..."
 echo
-docker-compose exec web composer --working-dir="/var/www/html/wp-content/plugins/smol-links" install
+docker compose exec web composer --working-dir="/var/www/html/wp-content/plugins/smol-links" install
 echo
 
 echo "Running npm install..."

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: dphiffer
 Donate link: https://themarkup.org/donate
 Tags: short url, shlink
 Requires at least: 4.5
-Tested up to: 6.5.4
+Tested up to: 6.6
 Requires PHP: 7.3
 Stable tag: 0.4.1
 License: GPLv2 or later


### PR DESCRIPTION
Update to [Compose v2](https://docs.docker.com/compose/migrate/), as of Docker Desktop 27.0.3 I'm seeing this:

```
./bin/start: line 17: docker-compose: command not found
```