### PR TITLE
Allow 1-char base domain

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -215,7 +215,7 @@ class Settings {
 		echo '<input 
 				type="url" 
 				placeholder="https://example.com" 
-				pattern="^(http(s){0,1}:\/\/.){0,1}[\-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([\-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$" 
+				pattern="^(https?:\/\/){0,1}[\-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{2,6}\b([\-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$" 
 				name="smol_links_options[base_url]" 
 				class="regular-text ltr" 
 				value="' . esc_attr($value) . '"


### PR DESCRIPTION
This PR updates the regrex used to validate base URL and allow 1-char short base domain like `x.com` for example.

I didn't figured out the meaning of `.` in http pattern matching group so I've removed it, as well as adjusted the pattern.

I've tested the pattern with https://regex101.com/ and the following test cases:

```
https://example.com
http://example.com
https://x.com
http://x.com
https://.null
http://.null
https://x.x
http://x.x
https://sth.longer
http://sth.longer
https://sth.reallylong
http://sth.reallylong
```

And I've also manually updated the plugin installed on my WP and it appears working as expected.